### PR TITLE
Hot Fix: Successful Response with Encrypted password

### DIFF
--- a/routes/apis/users.js
+++ b/routes/apis/users.js
@@ -23,9 +23,7 @@ router.post(
     ],
     async (req, res) => {
         const errors = validationResult(req);
-
-        console.log('Test');
-        console.log(req.query);
+        
         // If there are any errors found by validationResult in user's HTTP request, we'll return an HTTP status code 400
         // with an array of errors found
         if (!errors.isEmpty()) {
@@ -60,7 +58,7 @@ router.post(
             // Save onto database
             await user.save();
 
-            res.send('User registered');
+            res.send({'msg': 'User registered!'});
         } catch (err) {
             console.error(err.message);
             res.status(500).send('Server Error');


### PR DESCRIPTION
Ref. Issue #26 

The backend can now encrypt the "password" field without failing. The Swift code must have:

`request.addValue("application/json", forHTTPHeaderField: "Content-Type")`

The reason why we had an issue with this is because when our backend receives the json from frontend, it was thinking it was getting a "Content-Type: application/html". The frontend is also expecting a json back, so this commit returned exactly that.